### PR TITLE
seconds behavior improved

### DIFF
--- a/src/components/ContentView.tsx
+++ b/src/components/ContentView.tsx
@@ -523,9 +523,9 @@ useEffect(() => {
               color="red"
             />
 
-            {countdown !== null && (
-              <Text style={styles.countdown}>{countdown} s</Text>
-            )}
+          {countdown !== null && steps[currentStepIndex].duration && (
+                  <Text style={styles.countdown}>{countdown} s</Text>
+                )}
             <Text style={styles.dictatingTextContainer}>
               <Text style={styles.stepOfSteps}>Step {currentStepIndex + 1} of {steps.length}</Text>
               {'\n'}


### PR DESCRIPTION
Fixing the problem of displaying seconds from the previous step, when the next step doesn't have specified timeout.